### PR TITLE
iconv: use GNU version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,9 +44,15 @@ RUN apk update && apk add \
 	php7-xmlwriter \
 	php7-xml \
 	php7-xsl \
+	# see https://github.com/elecena/python-php/issues/8
+	# The problem seems to be that iconv in musl is not implemented to support that conversion, when using GNU iconv it works.
+	gnu-libiconv \
 	&& rm -rf /tmp/* /var/log/* /var/cache/*
 
-ENV PHP_VERSION 7.3.16
+ENV PHP_VERSION 7.3.17
+
+# use GNU iconv in php
+ENV LD_PRELOAD="/usr/lib/preloadable_libiconv.so php-fpm7 php"
 
 # add an info script
 WORKDIR /opt

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Python 3.8.2
 virtualenv 20.0.17 from /usr/local/lib/python3.8/site-packages/virtualenv/__init__.py
 
 ### PHP
-PHP 7.3.16 (cli) (built: Mar 20 2020 11:26:40) ( NTS )
+PHP 7.3.17 (cli) (built: Apr 16 2020 23:18:12) ( NTS )
 Copyright (c) 1997-2018 The PHP Group
-Zend Engine v3.3.16, Copyright (c) 1998-2018 Zend Technologies
-    with Zend OPcache v7.3.16, Copyright (c) 1999-2018, by Zend Technologies
+Zend Engine v3.3.17, Copyright (c) 1998-2018 Zend Technologies
+    with Zend OPcache v7.3.17, Copyright (c) 1999-2018, by Zend Technologies
 Composer version 1.10.5 2020-04-10 11:44:22
 [PHP Modules]
 calendar


### PR DESCRIPTION
`iconv(): Wrong charset, conversion from `utf-8' to `utf-8//IGNORE' is not allowed`

Fixes #8

See https://github.com/Icinga/icingaweb2-module-director/issues/2052

And this one works now:

```
/opt # php -r 'echo iconv("utf-8", "utf-8//IGNORE", "fooą\n");'
fooą
```